### PR TITLE
💄 UI: #25 - Search 탭 검색결과 도서 이미지 비율 변경 

### DIFF
--- a/Bookie/Bookie/Custom Views/Cells/SearchResultCell/SearchResultCell.swift
+++ b/Bookie/Bookie/Custom Views/Cells/SearchResultCell/SearchResultCell.swift
@@ -30,7 +30,7 @@ class SearchResultCell: UITableViewCell {
 
   override func layoutSubviews() {
     super.layoutSubviews()
-    contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0))
+    contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12))
   }
 
   func setContents(book: Item) {
@@ -42,30 +42,35 @@ class SearchResultCell: UITableViewCell {
   // MARK: Private
 
   private func configureUI() {
+    let padding: CGFloat = 8
     selectionStyle = .none
     backgroundColor = UIColor(resource: .bkBackground)
 
-    contentView.addSubview(coverImageView)
-    contentView.addSubview(titleLabel)
-    contentView.addSubview(authorLabel)
-
-    let padding: CGFloat = 8
+    let containerView = UIView()
+    containerView.translatesAutoresizingMaskIntoConstraints = false
+    containerView.addSubviews(coverImageView, titleLabel, authorLabel)
+    contentView.addSubview(containerView)
 
     NSLayoutConstraint.activate([
-      coverImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
-      coverImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: padding),
-      coverImageView.widthAnchor.constraint(equalToConstant: 100),
-      coverImageView.heightAnchor.constraint(equalToConstant: 100),
-      coverImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+      containerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+      containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      containerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+      containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
-      titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: padding),
+      coverImageView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+      coverImageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+      coverImageView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: padding),
+      coverImageView.widthAnchor.constraint(equalToConstant: 85),
+
+      titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: padding),
       titleLabel.leadingAnchor.constraint(equalTo: coverImageView.trailingAnchor, constant: padding),
-      titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-      titleLabel.bottomAnchor.constraint(equalTo: authorLabel.topAnchor, constant: padding),
+      titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -padding),
+      titleLabel.bottomAnchor.constraint(equalTo: authorLabel.topAnchor, constant: -padding),
+      titleLabel.heightAnchor.constraint(equalToConstant: 20),
 
       authorLabel.leadingAnchor.constraint(equalTo: coverImageView.trailingAnchor, constant: padding),
-      authorLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-      authorLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: padding),
+      authorLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -padding),
+      authorLabel.heightAnchor.constraint(equalToConstant: 18)
     ])
   }
 

--- a/Bookie/Bookie/Custom Views/ImageViews/BKCoverImageView.swift
+++ b/Bookie/Bookie/Custom Views/ImageViews/BKCoverImageView.swift
@@ -38,7 +38,7 @@ class BKCoverImageView: UIImageView {
     layer.cornerRadius = 10
     clipsToBounds = true
     image = placeholderImage
-    contentMode = .scaleToFill
+    contentMode = .scaleAspectFill
   }
 
 }

--- a/Bookie/Bookie/Custom Views/Labels/BKBodyLabel.swift
+++ b/Bookie/Bookie/Custom Views/Labels/BKBodyLabel.swift
@@ -23,9 +23,7 @@ class BKBodyLabel: UILabel {
   convenience init(textAlignment: NSTextAlignment, fontSize: CGFloat) {
     self.init(frame: .zero)
     self.textAlignment = textAlignment
-    guard let customFont = UIFont(name: Fonts.HanSansNeo.regular, size: fontSize) else { return }
-    font = UIFontMetrics(forTextStyle: .body).scaledFont(for: customFont)
-    adjustsFontForContentSizeCategory = true
+    font = UIFont(name: Fonts.HanSansNeo.regular, size: fontSize)
   }
 
   // MARK: Private

--- a/Bookie/Bookie/Custom Views/Labels/BKTitleLabel.swift
+++ b/Bookie/Bookie/Custom Views/Labels/BKTitleLabel.swift
@@ -23,9 +23,7 @@ class BKTitleLabel: UILabel {
   convenience init(textAlignment: NSTextAlignment, fontSize: CGFloat) {
     self.init(frame: .zero)
     self.textAlignment = textAlignment
-    guard let customFont = UIFont(name: Fonts.HanSansNeo.medium, size: fontSize) else { return }
-    font = UIFontMetrics(forTextStyle: .title1).scaledFont(for: customFont)
-    adjustsFontForContentSizeCategory = true
+    font = UIFont(name: Fonts.HanSansNeo.medium, size: fontSize)
   }
 
   // MARK: Private

--- a/Bookie/Bookie/Extensions/UIView+.swift
+++ b/Bookie/Bookie/Extensions/UIView+.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UIView {
-  func addSubViews(_ views: UIView...) {
-    for view in views { view.addSubview(view) }
+  func addSubviews(_ views: UIView...) {
+    for view in views { self.addSubview(view) }
   }
 }

--- a/Bookie/Bookie/Managers/NetworkManager.swift
+++ b/Bookie/Bookie/Managers/NetworkManager.swift
@@ -23,7 +23,7 @@ final class NetworkManager {
 
   // MARK: - Methods
   func searchBookInformation(for keyword: String, page: Int, completion: @escaping (Result<SearchResult, BKError>) -> Void) {
-    let endPoint = baseURL + "&Query=\(keyword)&MaxResults=50&Cover=Mid&start=\(page)&SearchTarget=All&output=js&Version=20131101"
+    let endPoint = baseURL + "&Query=\(keyword)&MaxResults=50&Cover=Big&start=\(page)&SearchTarget=All&output=js&Version=20131101"
 
     guard let url = URL(string: endPoint) else {
       completion(.failure(.invalidURL))

--- a/Bookie/Bookie/Screens/SearchViewController.swift
+++ b/Bookie/Bookie/Screens/SearchViewController.swift
@@ -71,8 +71,9 @@ class SearchViewController: UIViewController {
     tableView.delegate = self
     tableView.dataSource = self
     tableView.separatorStyle = .singleLine
-    tableView.separatorColor = .darkGray
-    tableView.rowHeight = 120
+    tableView.separatorColor = .systemGray
+    tableView.separatorInset = .init(top: 0, left: 12, bottom: 0, right: 12)
+    tableView.rowHeight = 165
     tableView.register(SearchResultCell.self, forCellReuseIdentifier: SearchResultCell.reuseID)
   }
 
@@ -99,7 +100,7 @@ extension SearchViewController: UISearchBarDelegate {
 extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
 
   func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
-    results.count
+    return results.count
   }
 
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
# About
- Issue: #25 
 
## Changes
도서 검색 결과시 나타나는 이미지의 비율을 변경했습니다.

## Screenshot

| 기능    | 스크린샷 |
|---------|----------|
| GIF/PNG | <img src = "https://github.com/jekyun-park/Bookie/assets/19788294/e840e674-fdc4-4fad-94e6-e07a8c8aa068" width="25%"> |

- Close #25 

